### PR TITLE
Changed default to 48

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -4,7 +4,7 @@ Config = Config or {}
 Config.OpenKey = 'HOME' -- https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/
 
 -- Max Server Players
-Config.MaxPlayers = GetConvarInt('sv_maxclients', 64) -- It returnes 64 if it cant find the Convar Int
+Config.MaxPlayers = GetConvarInt('sv_maxclients', 48) -- It returns 48 if it cant find the Convar Int
 
 -- Minimum Police for Actions
 Config.IllegalActions = {


### PR DESCRIPTION
Changed default to 48 since that's the max player count with a free license using OneSync Infinity.