### PR TITLE
 [ENHANCEMENT] Removing a config callback 

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -54,12 +54,6 @@ end
 
 -- Events
 
-RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-    QBCore.Functions.TriggerCallback('qb-scoreboard:server:GetConfig', function(config)
-        Config.IllegalActions = config
-    end)
-end)
-
 RegisterNetEvent('qb-scoreboard:client:SetActivityBusy', function(activity, busy)
     Config.IllegalActions[activity].busy = busy
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Scoreboard'
-version '1.2.0'
+version '1.2.1'
 
 ui_page 'html/ui.html'
 

--- a/server.lua
+++ b/server.lua
@@ -1,9 +1,5 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
-QBCore.Functions.CreateCallback('qb-scoreboard:server:GetConfig', function(_, cb)
-    cb(Config.IllegalActions)
-end)
-
 QBCore.Functions.CreateCallback('qb-scoreboard:server:GetScoreboardData', function(_, cb)
     local totalPlayers = 0
     local policeCount = 0


### PR DESCRIPTION
**Describe Pull request**
Removing this callback is because of the shared config on fxmanifest which means it doesn't need have a callback to get illegal items when player load I even tested it and it works with no problem.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
